### PR TITLE
Snapshot dependency options

### DIFF
--- a/teamcity/resource_snapshot_dependency.go
+++ b/teamcity/resource_snapshot_dependency.go
@@ -2,9 +2,16 @@ package teamcity
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 
 	api "github.com/cvbarros/go-teamcity-sdk/teamcity"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+var (
+	runBuildOptions = []string{"RUN_ADD_PROBLEM", "RUN", "MAKE_FAILED_TO_START", "CANCEL"}
 )
 
 func resourceSnapshotDependency() *schema.Resource {
@@ -27,6 +34,38 @@ func resourceSnapshotDependency() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"run_build_if_dependency_failed": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      api.DefaultSnapshotDependencyOptions.OnFailedDependency,
+				ValidateFunc: validation.StringInSlice(runBuildOptions, false),
+			},
+			"run_build_if_dependency_failed_to_start": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      api.DefaultSnapshotDependencyOptions.OnFailedToStartOrCanceledDependency,
+				ValidateFunc: validation.StringInSlice(runBuildOptions, false),
+			},
+			"run_build_on_the_same_agent": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  api.DefaultSnapshotDependencyOptions.RunSameAgent,
+				ForceNew: true,
+			},
+			"take_started_build_with_same_revisions": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  api.DefaultSnapshotDependencyOptions.DoNotRunNewBuildIfThereIsASuitable,
+				ForceNew: true,
+			},
+			"take_successful_builds_only": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  api.DefaultSnapshotDependencyOptions.TakeSuccessfulBuildsOnly,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -43,9 +82,10 @@ func resourceSnapshotDependencyCreate(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("invalid build_config_id '%s' - Build configuration does not exist", buildConfigID)
 	}
 
-	depService := client.DependencyService(buildConfigID)
-	dep := api.NewSnapshotDependency(d.Get("source_build_config_id").(string))
+	opts := getSnapshotDependencyOptions(d)
+	dep := api.NewSnapshotDependencyWithOptions(d.Get("source_build_config_id").(string), opts)
 
+	depService := client.DependencyService(buildConfigID)
 	out, err := depService.AddSnapshotDependency(dep)
 
 	if err != nil {
@@ -55,6 +95,73 @@ func resourceSnapshotDependencyCreate(d *schema.ResourceData, meta interface{}) 
 	d.SetId(out.ID)
 
 	return resourceSnapshotDependencyRead(d, meta)
+}
+
+func getSnapshotDependencyOptions(d *schema.ResourceData) *api.SnapshotDependencyOptions {
+	// Initialize as a copy of defaults
+	opts := *api.DefaultSnapshotDependencyOptions
+
+	if v, ok := d.GetOk("run_build_if_dependency_failed"); ok {
+		opts.OnFailedDependency = v.(string)
+	}
+	if v, ok := d.GetOk("run_build_if_dependency_failed_to_start"); ok {
+		opts.OnFailedToStartOrCanceledDependency = v.(string)
+	}
+	if v, ok := d.GetOkExists("run_build_on_the_same_agent"); ok {
+		opts.RunSameAgent = v.(bool)
+	}
+	if v, ok := d.GetOkExists("take_started_build_with_same_revisions"); ok {
+		opts.DoNotRunNewBuildIfThereIsASuitable = v.(bool)
+	}
+	if v, ok := d.GetOkExists("take_successful_builds_only"); ok {
+		opts.TakeSuccessfulBuildsOnly = v.(bool)
+	}
+
+	return &opts
+}
+
+func setSnapshotDependencyProperties(d *schema.ResourceData, p *api.Properties) error {
+	if err := setSnapshotDependencyStringProperty(d, p, "run-build-if-dependency-failed"); err != nil {
+		return err
+	}
+	if err := setSnapshotDependencyStringProperty(d, p, "run-build-if-dependency-failed-to-start"); err != nil {
+		return err
+	}
+	if err := setSnapshotDependencyBoolProperty(d, p, "run-build-on-the-same-agent"); err != nil {
+		return err
+	}
+	if err := setSnapshotDependencyBoolProperty(d, p, "take-started-build-with-same-revisions"); err != nil {
+		return err
+	}
+	if err := setSnapshotDependencyBoolProperty(d, p, "take-successful-builds-only"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func setSnapshotDependencyStringProperty(d *schema.ResourceData, p *api.Properties, propName string) error {
+	if v, ok := p.GetOk(propName); ok {
+		schemaName := strings.ReplaceAll(propName, "-", "_")
+		if err := d.Set(schemaName, v); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func setSnapshotDependencyBoolProperty(d *schema.ResourceData, p *api.Properties, propName string) error {
+	if v, ok := p.GetOk(propName); ok {
+		schemaName := strings.ReplaceAll(propName, "-", "_")
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return err
+		}
+		if err := d.Set(schemaName, b); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func resourceSnapshotDependencyRead(d *schema.ResourceData, meta interface{}) error {
@@ -69,7 +176,11 @@ func resourceSnapshotDependencyRead(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-	return d.Set("source_build_config_id", dt.SourceBuildType.ID)
+	if err := d.Set("source_build_config_id", dt.SourceBuildType.ID); err != nil {
+		return err
+	}
+
+	return setSnapshotDependencyProperties(d, dt.Properties)
 }
 
 func resourceSnapshotDependencyDelete(d *schema.ResourceData, meta interface{}) error {
@@ -80,7 +191,6 @@ func resourceSnapshotDependencyDelete(d *schema.ResourceData, meta interface{}) 
 }
 
 func getSnapshotDependency(c *api.DependencyService, id string) (*api.SnapshotDependency, error) {
-
 	dt, err := c.GetSnapshotByID(id)
 	if err != nil {
 		return nil, err

--- a/teamcity/resource_snapshot_dependency_test.go
+++ b/teamcity/resource_snapshot_dependency_test.go
@@ -2,6 +2,7 @@ package teamcity_test
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -26,6 +27,11 @@ func TestAccTeamcitySnapshotDependency_Basic(t *testing.T) {
 					testAccCheckBuildConfigExists("teamcity_build_config.config", &bc),
 					testAccCheckTeamcitySnapshotDependencyExists(resName, &bc.ID, &sd),
 					resource.TestCheckResourceAttrPtr(resName, "build_config_id", &sd.BuildTypeID),
+					resource.TestCheckResourceAttr(resName, "run_build_if_dependency_failed", api.DefaultSnapshotDependencyOptions.OnFailedDependency),
+					resource.TestCheckResourceAttr(resName, "run_build_if_dependency_failed_to_start", api.DefaultSnapshotDependencyOptions.OnFailedToStartOrCanceledDependency),
+					resource.TestCheckResourceAttr(resName, "run_build_on_the_same_agent", strconv.FormatBool(api.DefaultSnapshotDependencyOptions.RunSameAgent)),
+					resource.TestCheckResourceAttr(resName, "take_started_build_with_same_revisions", strconv.FormatBool(api.DefaultSnapshotDependencyOptions.DoNotRunNewBuildIfThereIsASuitable)),
+					resource.TestCheckResourceAttr(resName, "take_successful_builds_only", strconv.FormatBool(api.DefaultSnapshotDependencyOptions.TakeSuccessfulBuildsOnly)),
 					testAccCheckSnapshotSourceBuildType(resName, &sd),
 				),
 			},
@@ -49,6 +55,11 @@ func TestAccTeamcitySnapshotDependency_Updated(t *testing.T) {
 					testAccCheckBuildConfigExists("teamcity_build_config.config", &bc),
 					testAccCheckTeamcitySnapshotDependencyExists(resName, &bc.ID, &sd),
 					resource.TestCheckResourceAttrPtr(resName, "build_config_id", &sd.BuildTypeID),
+					resource.TestCheckResourceAttr(resName, "run_build_if_dependency_failed", api.DefaultSnapshotDependencyOptions.OnFailedDependency),
+					resource.TestCheckResourceAttr(resName, "run_build_if_dependency_failed_to_start", api.DefaultSnapshotDependencyOptions.OnFailedToStartOrCanceledDependency),
+					resource.TestCheckResourceAttr(resName, "run_build_on_the_same_agent", strconv.FormatBool(api.DefaultSnapshotDependencyOptions.RunSameAgent)),
+					resource.TestCheckResourceAttr(resName, "take_started_build_with_same_revisions", strconv.FormatBool(api.DefaultSnapshotDependencyOptions.DoNotRunNewBuildIfThereIsASuitable)),
+					resource.TestCheckResourceAttr(resName, "take_successful_builds_only", strconv.FormatBool(api.DefaultSnapshotDependencyOptions.TakeSuccessfulBuildsOnly)),
 					testAccCheckSnapshotSourceBuildType(resName, &sd),
 				),
 			},
@@ -58,6 +69,11 @@ func TestAccTeamcitySnapshotDependency_Updated(t *testing.T) {
 					testAccCheckBuildConfigExists("teamcity_build_config.config", &bc),
 					testAccCheckTeamcitySnapshotDependencyExists(resName, &bc.ID, &sd),
 					resource.TestCheckResourceAttr(resName, "source_build_config_id", "Snapshot_Dependency2"),
+					resource.TestCheckResourceAttr(resName, "run_build_if_dependency_failed", "MAKE_FAILED_TO_START"),
+					resource.TestCheckResourceAttr(resName, "run_build_if_dependency_failed_to_start", "CANCEL"),
+					resource.TestCheckResourceAttr(resName, "run_build_on_the_same_agent", "true"),
+					resource.TestCheckResourceAttr(resName, "take_started_build_with_same_revisions", "false"),
+					resource.TestCheckResourceAttr(resName, "take_successful_builds_only", "false"),
 				),
 			},
 		},
@@ -188,5 +204,10 @@ resource "teamcity_build_config" "config" {
 resource "teamcity_snapshot_dependency" "test" {
 	source_build_config_id = "${teamcity_build_config.dependency2.id}"
 	build_config_id = "${teamcity_build_config.config.id}"
+	run_build_if_dependency_failed = "MAKE_FAILED_TO_START"
+	run_build_if_dependency_failed_to_start = "CANCEL"
+	run_build_on_the_same_agent = "true"
+	take_started_build_with_same_revisions = "false"
+	take_successful_builds_only = "false"
 }
 `

--- a/teamcity/resource_snapshot_dependency_test.go
+++ b/teamcity/resource_snapshot_dependency_test.go
@@ -118,8 +118,13 @@ func snapshotDependencyDestroyHelper(s *terraform.State, bt *string, client *api
 			continue
 		}
 
+		var buildConfigID, snapshotID string
+		if _, err := fmt.Sscanf(r.Primary.ID, "%s %s", &buildConfigID, &snapshotID); err != nil {
+			return fmt.Errorf("Failed to parse ID '%s': %v", r.Primary.ID, err)
+		}
+
 		dep := client.DependencyService(*bt)
-		_, err := dep.GetSnapshotByID(r.Primary.ID)
+		_, err := dep.GetSnapshotByID(snapshotID)
 
 		if err != nil {
 			if strings.Contains(err.Error(), "404") {
@@ -150,8 +155,13 @@ func teamcitySnapshotDependencyExistsHelper(n string, bt *string, s *terraform.S
 		return fmt.Errorf("No ID is set")
 	}
 
+	var buildConfigID, snapshotID string
+	if _, err := fmt.Sscanf(rs.Primary.ID, "%s %s", &buildConfigID, &snapshotID); err != nil {
+		return fmt.Errorf("Failed to parse ID '%s': %v", rs.Primary.ID, err)
+	}
+
 	dep := client.DependencyService(*bt)
-	out, err := dep.GetSnapshotByID(rs.Primary.ID)
+	out, err := dep.GetSnapshotByID(snapshotID)
 	if err != nil {
 		return fmt.Errorf("Received an error retrieving snapshot dependency: %s", err)
 	}


### PR DESCRIPTION
## Snapshot Dependency Options

This adds support for configuring snapshot dependency options. The names of the options and their values directly correspond to the same names in TeamCity (at least as of 2018.2):

```
resource "teamcity_snapshot_dependency" "test" {
  build_config_id = ...
  source_build_config_id = ...

  run_build_if_dependency_failed          = "MAKE_FAILED_TO_START"
  run_build_if_dependency_failed_to_start = "CANCEL"
  run_build_on_the_same_agent             = true
  take_started_build_with_same_revisions  = false
  take_successful_builds_only             = false
}
```

## Globally Unique Snapshot Dependency IDs

This PR also makes snapshot dependency ID's globally unique; the following config previously would result in ID conflicts:

```
resource "teamcity_snapshot_dependency" "depdency_east" {
  config_id              = teamcity_build_config.deploy_east.id
  source_build_config_id = teamcity_build_config.build.id
}

resource "teamcity_snapshot_dependency" "dependency_west" {
  config_id              = teamcity_build_config.deploy_west.id
  source_build_config_id = teamcity_build_config.build.id
}
```

This was because the ID returned from TeamCity and `go-teamcity-sdk` was just the source build configuration's ID, which is only unique WRT its associated build configuration. This PR changes the IDs of snapshot dependencies from `<source_build_config_id>` `<build_id> <source_build_id>`. Note that this might be a breaking change for existing users, since encountering the old-style IDs will just result in an error; I went with this simpler approach but am happy to iterate to something that'll handle both cases if there's a clean way to do it).