### PR TITLE
Upgrade to TeamCity 2019.2.2 and SDK v1.0.0

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,5 @@
+export GO111MODULE=on
+export TEAMCITY_ADDR=http://localhost:8112
+export TF_ACC=1
+export TEAMCITY_USER=admin
+export TEAMCITY_PASSWORD=admin

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
   - docker
 language: go
 go:
- - "1.12.x"
+ - "1.13.x"
 env:
   global:
     - GO111MODULE=on
@@ -14,7 +14,9 @@ env:
     - TF_ACC=1
     - TEAMCITY_USER=admin
     - TEAMCITY_PASSWORD=admin
-
+before_install:
+  - sudo apt-get update
+  - sudo apt-get -y install bsdtar
 script:
   # run acceptance tests
  - ./integration_tests/start_teamcity.sh  # start and wait for TeamCity

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cvbarros/terraform-provider-teamcity
 go 1.12
 
 require (
-	github.com/cvbarros/go-teamcity v0.5.1
+	github.com/cvbarros/go-teamcity v1.0.0
 	github.com/dghubble/sling v1.3.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/hil v0.0.0-20190212132231-97b3a9cdfa93 // indirect

--- a/go.sum
+++ b/go.sum
@@ -98,6 +98,8 @@ github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d/go.mod h1:F5haX7
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cvbarros/go-teamcity v0.5.1 h1:J1ROlrKbd0Po7czImT1a307CdyDfcvf7X6GotDNR3TU=
 github.com/cvbarros/go-teamcity v0.5.1/go.mod h1:wQxn54gP1RHaDYuwwud9MRA+Y8VXfD3d5+ZjZCZLVVU=
+github.com/cvbarros/go-teamcity v1.0.0 h1:heOLoeAsWxmcMNqceNy2kGfFniZEnECvT47THFthDJs=
+github.com/cvbarros/go-teamcity v1.0.0/go.mod h1:rV0+Oe8VMB2m3mWKN/glUnzzh/4EB57i70W154tqYxo=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/integration_tests/docker-compose.yml
+++ b/integration_tests/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   server:
-    image: jetbrains/teamcity-server:2018.1.3
+    image: jetbrains/teamcity-server:2019.2.2
     ports:
       - "8112:8111"
     volumes:

--- a/integration_tests/start_teamcity.sh
+++ b/integration_tests/start_teamcity.sh
@@ -3,7 +3,7 @@ set -e
 
 pushd integration_tests/
 
-tar -xzf teamcity_data.tar.gz
+bsdtar -xzf teamcity_data.tar.gz
 
 docker-compose up -d
 


### PR DESCRIPTION
This PR bumps the SDK dependency to `v1.0.0` and updates the supported version in tests to TeamCity 2019.2.2.