### PR TITLE
terraform-provider-teamcity: update deps to yext versions r=atavakoli

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,17 +15,17 @@ Requirements
 Building The Provider
 ---------------------
 
-Clone repository to: `$GOPATH/src/github.com/cvbarros/terraform-provider-teamcity`
+Clone repository to: `$GOPATH/src/github.com/yext/terraform-provider-teamcity`
 
 ```sh
-$ mkdir -p $GOPATH/src/github.com/cvbarros/terraform-provider-teamcity; cd $GOPATH/src/github.com/cvbarros
+$ mkdir -p $GOPATH/src/github.com/yext/terraform-provider-teamcity; cd $GOPATH/src/github.com/cvbarros
 $ git clone git@github.com:cvbarros/terraform-provider-teamcity
 ```
 
 Enter the provider directory and build the provider
 
 ```sh
-$ cd $GOPATH/src/github.com/cvbarros/terraform-provider-teamcity
+$ cd $GOPATH/src/github.com/yext/terraform-provider-teamcity
 $ go build -o $GOPATH/bin/terraform-provider-teamcity
 ```
 

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"github.com/hashicorp/terraform/plugin"
 
-	"github.com/cvbarros/terraform-provider-teamcity/teamcity"
+	"github.com/yext/terraform-provider-teamcity/teamcity"
 )
 
 func main() {

--- a/teamcity/provider_test.go
+++ b/teamcity/provider_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cvbarros/terraform-provider-teamcity/teamcity"
+	"github.com/yext/terraform-provider-teamcity/teamcity"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"

--- a/teamcity/resource_vcs_root_git_test.go
+++ b/teamcity/resource_vcs_root_git_test.go
@@ -24,7 +24,7 @@ func TestAccVcsRootGit_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcsRootGitExists(resName, &vcs),
 					resource.TestCheckResourceAttr(resName, "name", "application"),
-					resource.TestCheckResourceAttr(resName, "fetch_url", "https://github.com/cvbarros/terraform-provider-teamcity"),
+					resource.TestCheckResourceAttr(resName, "fetch_url", "https://github.com/yext/terraform-provider-teamcity"),
 					resource.TestCheckResourceAttr(resName, "default_branch", "refs/head/master"),
 					resource.TestCheckResourceAttr(resName, "branches.#", "2"),
 					resource.TestCheckResourceAttr(resName, "branches.0", "+:refs/(pull/*)/head"),
@@ -53,7 +53,7 @@ func TestAccVcsRootGit_UpdateBasic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcsRootGitExists(resName, &vcs),
 					resource.TestCheckResourceAttr(resName, "name", "application"),
-					resource.TestCheckResourceAttr(resName, "fetch_url", "https://github.com/cvbarros/terraform-provider-teamcity"),
+					resource.TestCheckResourceAttr(resName, "fetch_url", "https://github.com/yext/terraform-provider-teamcity"),
 					resource.TestCheckResourceAttr(resName, "default_branch", "refs/head/master"),
 					resource.TestCheckResourceAttr(resName, "branches.#", "2"),
 					resource.TestCheckResourceAttr(resName, "branches.0", "+:refs/(pull/*)/head"),
@@ -271,7 +271,7 @@ resource "teamcity_project" "vcs_root_project" {
 resource "teamcity_vcs_root_git" "git_test" {
 	name = "application"
 	project_id = "${teamcity_project.vcs_root_project.id}"
-	fetch_url = "https://github.com/cvbarros/terraform-provider-teamcity"
+	fetch_url = "https://github.com/yext/terraform-provider-teamcity"
 	default_branch = "refs/head/master"
 	branches = [
     "+:refs/(pull/*)/head",
@@ -316,7 +316,7 @@ resource "teamcity_project" "vcs_root_project" {
 resource "teamcity_vcs_root_git" "git_test" {
 	name = "application"
 	project_id = "${teamcity_project.vcs_root_project.id}"
-	fetch_url = "https://github.com/cvbarros/terraform-provider-teamcity"
+	fetch_url = "https://github.com/yext/terraform-provider-teamcity"
 	default_branch = "refs/head/master"
 
 	auth {
@@ -335,7 +335,7 @@ resource "teamcity_project" "vcs_root_project" {
 resource "teamcity_vcs_root_git" "git_test" {
 	name = "application"
 	project_id = "${teamcity_project.vcs_root_project.id}"
-	fetch_url = "https://github.com/cvbarros/terraform-provider-teamcity"
+	fetch_url = "https://github.com/yext/terraform-provider-teamcity"
 	default_branch = "refs/head/master"
 
 	auth {
@@ -356,7 +356,7 @@ resource "teamcity_project" "vcs_root_project" {
 resource "teamcity_vcs_root_git" "git_test" {
 	name = "application"
 	project_id = "${teamcity_project.vcs_root_project.id}"
-	fetch_url = "https://github.com/cvbarros/terraform-provider-teamcity"
+	fetch_url = "https://github.com/yext/terraform-provider-teamcity"
 	default_branch = "refs/head/master"
 
 	agent {

--- a/website/r/vcs_root_git.html.md
+++ b/website/r/vcs_root_git.html.md
@@ -23,7 +23,7 @@ resource "teamcity_vcs_root_git" "vcsroot" {
   name       = "Application"
   project_id = "${teamcity_project.project.id}"
 
-  fetch_url = "https://github.com/cvbarros/terraform-provider-teamcity"
+  fetch_url = "https://github.com/yext/terraform-provider-teamcity"
 
   default_branch = "refs/head/master"
 


### PR DESCRIPTION
I'm not sure if this is necessary or even desirable, but i could not get the project to work locally without this change.

Previously this depended on the non-forked project which seemed to cause
the tests to fail to compile.

TEST=auto
dep ensure
go test ./...
  success