### PR TITLE
dependencies: updating github.com/cvbarros/go-teamcity to v1.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cvbarros/terraform-provider-teamcity
 go 1.13
 
 require (
-	github.com/cvbarros/go-teamcity v1.0.0
+	github.com/cvbarros/go-teamcity v1.1.0
 	github.com/dghubble/sling v1.3.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cvbarros/go-teamcity v1.0.0 h1:heOLoeAsWxmcMNqceNy2kGfFniZEnECvT47THFthDJs=
-github.com/cvbarros/go-teamcity v1.0.0/go.mod h1:rV0+Oe8VMB2m3mWKN/glUnzzh/4EB57i70W154tqYxo=
+github.com/cvbarros/go-teamcity v1.1.0 h1:Gh8hIbpMJwsLTsF/10yFxs3zEptn8jfmKckJR+CD8vU=
+github.com/cvbarros/go-teamcity v1.1.0/go.mod h1:rV0+Oe8VMB2m3mWKN/glUnzzh/4EB57i70W154tqYxo=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
I've also run `go mod vendor` - since in Golang it's convention for applications/binaries to check-in their dependencies - but for libraries they're omitted by convention