### PR TITLE
d/project: ensuring the parent_project_id is always set

### DIFF
--- a/teamcity/data_source_project.go
+++ b/teamcity/data_source_project.go
@@ -67,9 +67,7 @@ func dataSourceProjectRead(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(dt.ID)
 	d.Set("name", dt.Name)
 	d.Set("project_id", dt.ID)
-	if dt.ParentProject != nil {
-		d.Set("parent_project_id", dt.ParentProjectID)
-	}
+	d.Set("parent_project_id", dt.ParentProjectID)
 	d.Set("url", dt.WebURL)
 	return nil
 }

--- a/teamcity/data_source_project_test.go
+++ b/teamcity/data_source_project_test.go
@@ -12,12 +12,12 @@ func TestAccDataSourceProject_Root(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccDataSourceProjectRoot,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resName, "name", "<Root project>"),
 					resource.TestCheckResourceAttr(resName, "project_id", "_Root"),
-					resource.TestCheckNoResourceAttr(resName, "parent_project_id"),
+					resource.TestCheckResourceAttr(resName, "parent_project_id", ""),
 					resource.TestCheckResourceAttr(resName, "url", "http://127.0.0.1:8112/project.html?projectId=_Root"),
 				),
 			},
@@ -31,10 +31,10 @@ func TestAccDataSourceProject_Basic(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccDataSourceProject,
 			},
-			resource.TestStep{
+			{
 				Config: testAccDataSourceProject,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resName, "name", "Test Project"),
@@ -59,6 +59,6 @@ resource "teamcity_project" "project" {
 }
 
 data "teamcity_project" "project" {
-  name = "${teamcity_project.project.name}"
+  name = teamcity_project.project.name
 }
 `


### PR DESCRIPTION
As of Terraform 0.12, fields always need to have a value in the config, else they're set to `null` and thus will cause an issue at runtime. This fixes this in the Project Data Source & removes some unnecessary code from the tests