### PR TITLE
r/project: ensuring that all fields are set

### DIFF
--- a/teamcity/errors.go
+++ b/teamcity/errors.go
@@ -1,0 +1,7 @@
+package teamcity
+
+import "strings"
+
+func isNotFoundError(err error) bool {
+	return strings.Contains(err.Error(), "404")
+}

--- a/teamcity/resource_agent_requirement.go
+++ b/teamcity/resource_agent_requirement.go
@@ -2,6 +2,7 @@ package teamcity
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 
@@ -92,6 +93,13 @@ func resourceAgentRequirementRead(d *schema.ResourceData, meta interface{}) erro
 
 	dt, err := getAgentRequirement(client, d.Id())
 	if err != nil {
+		// handles this being deleted outside of TF
+		if isNotFoundError(err) {
+			log.Printf("[DEBUG] Agent Requirement was not found - removing from state!")
+			d.SetId("")
+			return nil
+		}
+
 		return err
 	}
 

--- a/teamcity/resource_artifact_dependency.go
+++ b/teamcity/resource_artifact_dependency.go
@@ -2,6 +2,7 @@ package teamcity
 
 import (
 	"fmt"
+	"log"
 
 	api "github.com/cvbarros/go-teamcity/teamcity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -101,6 +102,13 @@ func resourceArtifactDependencyRead(d *schema.ResourceData, meta interface{}) er
 
 	dt, err := getArtifactDependency(client, d.Id())
 	if err != nil {
+		// handles this being deleted outside of TF
+		if isNotFoundError(err) {
+			log.Printf("[DEBUG] Build Trigger Artifact Dependency was not found - removing from state!")
+			d.SetId("")
+			return nil
+		}
+
 		return err
 	}
 

--- a/teamcity/resource_build_config.go
+++ b/teamcity/resource_build_config.go
@@ -425,6 +425,13 @@ func resourceBuildConfigRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] resourceBuildConfigRead started for resouceId: %v", d.Id())
 	dt, err := getBuildConfiguration(client, d.Id())
 	if err != nil {
+		// handles this being deleted outside of TF
+		if isNotFoundError(err) {
+			log.Printf("[DEBUG] Build Configuration was not found - removing from state!")
+			d.SetId("")
+			return nil
+		}
+
 		return err
 	}
 	log.Printf("[DEBUG] BuildConfiguration '%v' retrieved successfully", dt.Name)

--- a/teamcity/resource_build_config.go
+++ b/teamcity/resource_build_config.go
@@ -283,14 +283,12 @@ func resourceBuildConfigCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	created, err := client.BuildTypes.Create(projectID, bt)
-
 	if err != nil {
 		return err
 	}
 
 	log.Printf("[DEBUG] resourceBuildConfigCreate: sucessfully created build configuration with id = '%v'. Marking new resource.", created.ID)
 
-	d.MarkNewResource()
 	d.SetId(created.ID)
 	d.Partial(true)
 

--- a/teamcity/resource_build_trigger_build_finish.go
+++ b/teamcity/resource_build_trigger_build_finish.go
@@ -96,6 +96,13 @@ func resourceBuildTriggerBuildFinishRead(d *schema.ResourceData, meta interface{
 
 	ret, err := getTrigger(client, d.Id())
 	if err != nil {
+		// handles this being deleted outside of TF
+		if isNotFoundError(err) {
+			log.Printf("[DEBUG] Build Trigger Build Finish was not found - removing from state!")
+			d.SetId("")
+			return nil
+		}
+
 		return err
 	}
 	dt, ok := ret.(*api.TriggerBuildFinish)

--- a/teamcity/resource_build_trigger_schedule.go
+++ b/teamcity/resource_build_trigger_schedule.go
@@ -2,6 +2,7 @@ package teamcity
 
 import (
 	"fmt"
+	"log"
 
 	api "github.com/cvbarros/go-teamcity/teamcity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -177,6 +178,13 @@ func resourceBuildTriggerScheduleRead(d *schema.ResourceData, meta interface{}) 
 
 	ret, err := getTrigger(client, d.Id())
 	if err != nil {
+		// handles this being deleted outside of TF
+		if isNotFoundError(err) {
+			log.Printf("[DEBUG] Build Trigger Schedule was not found - removing from state!")
+			d.SetId("")
+			return nil
+		}
+
 		return err
 	}
 	dt, ok := ret.(*api.TriggerSchedule)

--- a/teamcity/resource_build_trigger_vcs.go
+++ b/teamcity/resource_build_trigger_vcs.go
@@ -2,6 +2,7 @@ package teamcity
 
 import (
 	"fmt"
+	"log"
 
 	api "github.com/cvbarros/go-teamcity/teamcity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -82,6 +83,13 @@ func resourceBuildTriggerVcsRead(d *schema.ResourceData, meta interface{}) error
 
 	ret, err := getTrigger(client, d.Id())
 	if err != nil {
+		// handles this being deleted outside of TF
+		if isNotFoundError(err) {
+			log.Printf("[DEBUG] Build Trigger VCS was not found - removing from state!")
+			d.SetId("")
+			return nil
+		}
+
 		return err
 	}
 	dt, ok := ret.(*api.TriggerVcs)

--- a/teamcity/resource_feature_commit_status_publisher.go
+++ b/teamcity/resource_feature_commit_status_publisher.go
@@ -3,6 +3,7 @@ package teamcity
 import (
 	"bytes"
 	"fmt"
+	"log"
 	"strings"
 
 	api "github.com/cvbarros/go-teamcity/teamcity"
@@ -115,6 +116,13 @@ func resourceFeatureCommitStatusPublisherRead(d *schema.ResourceData, meta inter
 
 	dt, err := getBuildFeatureCommitPublisher(client, d.Id())
 	if err != nil {
+		// handles this being deleted outside of TF
+		if isNotFoundError(err) {
+			log.Printf("[DEBUG] Build Feature Commit Status Publisher was not found - removing from state!")
+			d.SetId("")
+			return nil
+		}
+
 		return err
 	}
 

--- a/teamcity/resource_group.go
+++ b/teamcity/resource_group.go
@@ -75,7 +75,6 @@ func resourceGroupCreate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	d.MarkNewResource()
 	d.SetId(created.Key)
 
 	return resourceGroupRead(d, meta)

--- a/teamcity/resource_group.go
+++ b/teamcity/resource_group.go
@@ -3,6 +3,7 @@ package teamcity
 import (
 	"fmt"
 	"hash/crc32"
+	"log"
 	"regexp"
 	"strings"
 
@@ -97,10 +98,13 @@ func resourceGroupRead(d *schema.ResourceData, meta interface{}) error {
 
 	dt, err := client.Groups.GetByKey(d.Id())
 	if err != nil {
-		if strings.Contains(err.Error(), "404") {
+		// handles this being deleted outside of TF
+		if isNotFoundError(err) {
+			log.Printf("[DEBUG] User Group was not found - removing from state!")
 			d.SetId("")
 			return nil
 		}
+
 		return err
 	}
 	if err := d.Set("key", dt.Key); err != nil {

--- a/teamcity/resource_project.go
+++ b/teamcity/resource_project.go
@@ -2,9 +2,10 @@ package teamcity
 
 import (
 	"fmt"
+	"log"
+
 	api "github.com/cvbarros/go-teamcity/teamcity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"log"
 )
 
 func resourceProject() *schema.Resource {
@@ -50,19 +51,11 @@ func resourceProject() *schema.Resource {
 
 func resourceProjectCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*api.Client)
-	var name, parentID string
 
-	if v, ok := d.GetOk("name"); ok {
-		name = v.(string)
-	}
+	name := d.Get("name").(string)
+	parentProjectId := d.Get("parent_id").(string)
 
-	if v, ok := d.GetOk("parent_id"); ok {
-		if v != "" {
-			parentID = v.(string)
-		}
-	}
-
-	newProj, err := api.NewProject(name, "", parentID)
+	newProj, err := api.NewProject(name, "", parentProjectId)
 	if err != nil {
 		return err
 	}
@@ -110,22 +103,22 @@ func resourceProjectUpdate(d *schema.ResourceData, meta interface{}) error {
 func resourceProjectRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*api.Client)
 
-	dt, err := getProject(client, d.Id())
+	dt, err := client.Projects.GetByID(d.Id())
 	if err != nil {
-		return err
-	}
-	if err := d.Set("name", dt.Name); err != nil {
-		return err
-	}
-	if err := d.Set("description", dt.Description); err != nil {
-		return err
-	}
-	if err := d.Set("parent_id", dt.ParentProject.ID); err != nil {
+		if isNotFoundError(err) {
+			log.Printf("[DEBUG] Project has been removed outside of Terraform - removing from state!")
+			d.SetId("")
+			return nil
+		}
+
 		return err
 	}
 
-	flattenParameterCollection(d, dt.Parameters)
-	return nil
+	d.Set("name", dt.Name)
+	d.Set("description", dt.Description)
+	d.Set("parent_id", dt.ParentProjectID)
+
+	return flattenParameterCollection(d, dt.Parameters)
 }
 
 func resourceProjectDelete(d *schema.ResourceData, meta interface{}) error {
@@ -141,13 +134,4 @@ func resourceProjectImport(d *schema.ResourceData, meta interface{}) ([]*schema.
 		return nil, err
 	}
 	return []*schema.ResourceData{d}, nil
-}
-
-func getProject(c *api.Client, id string) (*api.Project, error) {
-	dt, err := c.Projects.GetByID(id)
-	if err != nil {
-		return nil, err
-	}
-
-	return dt, nil
 }

--- a/teamcity/resource_project.go
+++ b/teamcity/resource_project.go
@@ -104,8 +104,9 @@ func resourceProjectRead(d *schema.ResourceData, meta interface{}) error {
 
 	dt, err := client.Projects.GetByID(d.Id())
 	if err != nil {
+		// handles this being deleted outside of TF
 		if isNotFoundError(err) {
-			log.Printf("[DEBUG] Project has been removed outside of Terraform - removing from state!")
+			log.Printf("[DEBUG] Project was not found - removing from state!")
 			d.SetId("")
 			return nil
 		}

--- a/teamcity/resource_project.go
+++ b/teamcity/resource_project.go
@@ -65,7 +65,6 @@ func resourceProjectCreate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	d.MarkNewResource()
 	d.SetId(created.ID)
 
 	return resourceProjectUpdate(d, client)

--- a/teamcity/resource_snapshot_dependency.go
+++ b/teamcity/resource_snapshot_dependency.go
@@ -2,6 +2,7 @@ package teamcity
 
 import (
 	"fmt"
+	"log"
 
 	api "github.com/cvbarros/go-teamcity/teamcity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -62,6 +63,13 @@ func resourceSnapshotDependencyRead(d *schema.ResourceData, meta interface{}) er
 
 	dt, err := getSnapshotDependency(client, d.Id())
 	if err != nil {
+		// handles this being deleted outside of TF
+		if isNotFoundError(err) {
+			log.Printf("[DEBUG] Snapshot Dependency was not found - removing from state!")
+			d.SetId("")
+			return nil
+		}
+
 		return err
 	}
 

--- a/teamcity/resource_vcs_root_git.go
+++ b/teamcity/resource_vcs_root_git.go
@@ -14,9 +14,9 @@ import (
 
 func resourceVcsRootGit() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceVcsRootGitCreate,
+		Create: resourceVcsRootGitCreateUpdate,
 		Read:   resourceVcsRootGitRead,
-		Update: resourceVcsRootGitUpdate,
+		Update: resourceVcsRootGitCreateUpdate,
 		Delete: resourceVcsRootGitDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -182,12 +182,7 @@ var expandCleanFilesPolicyMap = map[string]string{
 
 var flattenCleanFilesPolicyMap = reverseMap(expandCleanFilesPolicyMap)
 
-func resourceVcsRootGitCreate(d *schema.ResourceData, meta interface{}) error {
-	d.MarkNewResource()
-	return resourceVcsRootGitUpdate(d, meta)
-}
-
-func resourceVcsRootGitUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceVcsRootGitCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*api.Client)
 	projectID := d.Get("project_id").(string)
 	var gitVcs *api.GitVcsRoot

--- a/teamcity/resource_vcs_root_git.go
+++ b/teamcity/resource_vcs_root_git.go
@@ -291,6 +291,13 @@ func resourceVcsRootGitRead(d *schema.ResourceData, meta interface{}) error {
 
 	vcs, err := client.VcsRoots.GetByID(vcsID)
 	if err != nil {
+		// handles this being deleted outside of TF
+		if isNotFoundError(err) {
+			log.Printf("[DEBUG] VCS Root was not found - removing from state!")
+			d.SetId("")
+			return nil
+		}
+
 		return err
 	}
 


### PR DESCRIPTION
This PR ensures that all fields within the `teamcity_project` resource have a value - which is required in Terraform 0.12.

There's a couple of other changes in here too, since I was passing through it felt worth making them everywhere at once, I hope you don't mind:

* all resources now support detecting when they've been deleted - this allows Terraform to detect when a resource has been deleted outside of Terraform and thus requires recreation when running `terraform plan`
* reusing the Create/Update function for VCS Root (since create was calling directly out to update anyway)
* removing the implied `d.MarkNewResource` - when Terraform calls into a Create function, the "isNew" field in the resource (which is what MarkNewResource sets) is set to true - so this call is superfluous and can be removed