### PR TITLE
provider: support for Token authentication

### DIFF
--- a/teamcity/config.go
+++ b/teamcity/config.go
@@ -9,11 +9,21 @@ import (
 // Config Used to configure an api client for TeamCity
 type Config struct {
 	Address  string
+	Token    string
 	Username string
 	Password string
 }
 
 // Client Returns a new TeamCity api client configured with this instance parameters
 func (c *Config) Client() (*api.Client, error) {
-	return api.NewWithAddress(c.Username, c.Password, c.Address, http.DefaultClient)
+	// `http.DefaultClient` doesn't configure a proxy by default - this does
+	httpClient := &http.Client{
+		Transport: http.DefaultTransport,
+	}
+
+	if c.Token != "" {
+		return api.NewClientWithAddress(api.TokenAuth(c.Token), c.Address, httpClient)
+	}
+
+	return api.NewClientWithAddress(api.BasicAuth(c.Username, c.Password), c.Address, httpClient)
 }

--- a/teamcity/provider_test.go
+++ b/teamcity/provider_test.go
@@ -34,10 +34,11 @@ func testAccPreCheck(t *testing.T) {
 	if v := os.Getenv("TEAMCITY_ADDR"); v == "" {
 		t.Fatal("TEAMCITY_ADDR must be set for acceptance tests")
 	}
-	if v := os.Getenv("TEAMCITY_USER"); v == "" {
-		t.Fatal("TEAMCITY_USER must be set for acceptance tests")
-	}
-	if v := os.Getenv("TEAMCITY_PASSWORD"); v == "" {
-		t.Fatal("TEAMCITY_PASSWORD must be set for acceptance tests")
+	hasToken := os.Getenv("TEAMCITY_TOKEN") != ""
+	hasUsername := os.Getenv("TEAMCITY_USER") != ""
+	hasPassword := os.Getenv("TEAMCITY_PASSWORD") != ""
+
+	if !hasToken && !(hasUsername && hasPassword) {
+		t.Fatal("Either `TEAMCITY_TOKEN` or `TEAMCITY_USER` and `TEAMCITY_PASSWORD` must be set for acceptance tests")
 	}
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -16,13 +16,24 @@ with the proper credentials before it can be used.
 This provider is meant primarily for enabling _pipelines as code_ for TeamCity.
 
 ## Provider Arguments
+
 The provider configuration block accepts the following arguments. In general, it's better to set them via indicated environment variables to keep the configuration safe.
 
 * `address` - (Required) Address of TeamCity server. This is a URL with a scheme, a hostname and port but no path. May be set via the `TEAMCITY_ADDR` environment variable.
 
+---
+
+If using Token Authentication - the following fields can be specified:
+
+* `token` - (Required) The API Token which should be used to authenticate to TeamCity. The user must have broad permissions to create resources and manage projects at the appropriate hierarchy path. Refer to TeamCity documentation on how to apply proper roles and permissions for the user. It is recommended to be set via `TEAMCITY_TOKEN` environment variable.
+
+---
+
+If using a Username/Password for authentication - the following fields can be specified:
+
 * `username` - (Required) Username that will be used to authenticate to TeamCity. The user must have broad permissions to create resources and manage projects at the appropriate hierarchy path. Refer to TeamCity documentation on how to apply proper roles and permissions for the user. It is recommended to be set via `TEAMCITY_USER` environment variable.
 
-* `password` - (Required) Matcnhing password for the user to authenticate to TeamCity. It is recommended to be set via `TEAMCITY_PASSWORD` environment variable.
+* `password` - (Required) Matching password for the user to authenticate to TeamCity. It is recommended to be set via `TEAMCITY_PASSWORD` environment variable.
 
 ## Example Usage
 
@@ -32,12 +43,10 @@ provider "teamcity" {
   # environment variables described above, so that each user can have
   # separate credentials set in the environment.
 
-  #This will default to using $TEAMCITY_ADDR
-  #But can be set excplicitly
-  #address = "http://127.0.0.1:8112" #Or via TEAMCITY_ADDR environment variable
+  address = "http://127.0.0.1:8112"
 }
 
-#Creates a project "Terraformed project" in the Root level hierarchy
+# Creates a project "Terraformed project" in the Root level hierarchy
 resource "teamcity_project" "project" {
   name = "Terraformed project"
 }


### PR DESCRIPTION
I've updated the acceptance tests to support using a token/username & password - and these pass:

```
$ go test -v ./teamcity/
=== RUN   TestAccDataSourceProject_Root
--- PASS: TestAccDataSourceProject_Root (0.10s)
=== RUN   TestAccDataSourceProject_Basic
--- PASS: TestAccDataSourceProject_Basic (0.36s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccTeamcityAgentRequirement_Basic
--- PASS: TestAccTeamcityAgentRequirement_Basic (0.73s)
=== RUN   TestAccTeamcityAgentRequirement_Update
--- PASS: TestAccTeamcityAgentRequirement_Update (1.31s)
=== RUN   TestAccTeamcityArtifactDependency_Basic
--- PASS: TestAccTeamcityArtifactDependency_Basic (1.33s)
=== RUN   TestAccTeamcityArtifactDependency_Update
--- PASS: TestAccTeamcityArtifactDependency_Update (1.84s)
=== RUN   TestAccTeamcityArtifactDependency_DependencyRevisionUpdate
--- PASS: TestAccTeamcityArtifactDependency_DependencyRevisionUpdate (1.31s)
=== RUN   TestAccTeamcityArtifactDependency_OptionsNoRevision
--- PASS: TestAccTeamcityArtifactDependency_OptionsNoRevision (1.01s)
=== RUN   TestAccTeamcityArtifactDependency_OptionsRevision
--- PASS: TestAccTeamcityArtifactDependency_OptionsRevision (0.94s)
=== RUN   TestAccTeamcityArtifactDependency_ConfigErrorForRevision
--- PASS: TestAccTeamcityArtifactDependency_ConfigErrorForRevision (0.65s)
=== RUN   TestAccBuildConfig_Basic
--- PASS: TestAccBuildConfig_Basic (1.12s)
=== RUN   TestAccBuildConfig_TemplateDoesNotSupportDescription
--- PASS: TestAccBuildConfig_TemplateDoesNotSupportDescription (0.34s)
=== RUN   TestAccBuildConfig_Template
--- PASS: TestAccBuildConfig_Template (0.53s)
=== RUN   TestAccBuildConfig_BasicBuildCounter
--- PASS: TestAccBuildConfig_BasicBuildCounter (1.71s)
=== RUN   TestAccBuildConfig_UpdateBuildCounter
--- PASS: TestAccBuildConfig_UpdateBuildCounter (1.77s)
=== RUN   TestAccBuildConfig_UpdateOtherSetting
--- PASS: TestAccBuildConfig_UpdateOtherSetting (1.73s)
=== RUN   TestAccBuildConfig_NestedProject
--- PASS: TestAccBuildConfig_NestedProject (1.20s)
=== RUN   TestAccBuildConfig_UpdateBasic
--- PASS: TestAccBuildConfig_UpdateBasic (2.11s)
=== RUN   TestAccBuildConfig_StepsAddAndRemove
--- PASS: TestAccBuildConfig_StepsAddAndRemove (2.12s)
=== RUN   TestAccBuildConfig_StepsPowershell
--- PASS: TestAccBuildConfig_StepsPowershell (1.23s)
=== RUN   TestAccBuildConfig_UpdateSteps
--- PASS: TestAccBuildConfig_UpdateSteps (1.97s)
=== RUN   TestAccBuildConfig_StepsCmdLine
--- PASS: TestAccBuildConfig_StepsCmdLine (0.92s)
=== RUN   TestAccBuildConfig_StepsCmdLineUpdateSteps
--- PASS: TestAccBuildConfig_StepsCmdLineUpdateSteps (2.06s)
=== RUN   TestAccBuildConfig_Parameters
--- PASS: TestAccBuildConfig_Parameters (1.46s)
=== RUN   TestAccBuildConfig_UpdateParameters
--- PASS: TestAccBuildConfig_UpdateParameters (1.46s)
=== RUN   TestAccBuildConfig_Settings
--- PASS: TestAccBuildConfig_Settings (0.65s)
=== RUN   TestAccBuildConfig_SettingsUpdate
--- PASS: TestAccBuildConfig_SettingsUpdate (1.20s)
=== RUN   TestAccBuildConfig_VcsRoot
--- PASS: TestAccBuildConfig_VcsRoot (0.70s)
=== RUN   TestAccBuildConfig_AttachTemplates
--- PASS: TestAccBuildConfig_AttachTemplates (1.56s)
=== RUN   TestAccTeamcityBuildTriggerBuildFinish_Basic
--- PASS: TestAccTeamcityBuildTriggerBuildFinish_Basic (1.06s)
=== RUN   TestAccTeamcityBuildTriggerBuildFinish_Update
--- PASS: TestAccTeamcityBuildTriggerBuildFinish_Update (1.82s)
=== RUN   TestAccTeamcityBuildTriggerSchedule_Daily
--- PASS: TestAccTeamcityBuildTriggerSchedule_Daily (0.94s)
=== RUN   TestAccTeamcityBuildTriggerSchedule_DailyUpdate
--- PASS: TestAccTeamcityBuildTriggerSchedule_DailyUpdate (1.43s)
=== RUN   TestAccTeamcityBuildTriggerSchedule_Weekly
--- PASS: TestAccTeamcityBuildTriggerSchedule_Weekly (0.86s)
=== RUN   TestAccTeamcityBuildTriggerSchedule_WeeklyUpdated
--- PASS: TestAccTeamcityBuildTriggerSchedule_WeeklyUpdated (1.94s)
=== RUN   TestAccTeamcityBuildTriggerSchedule_Options
--- PASS: TestAccTeamcityBuildTriggerSchedule_Options (1.77s)
=== RUN   TestAccTeamcityBuildTriggerSchedule_OptionsUpdated
--- PASS: TestAccTeamcityBuildTriggerSchedule_OptionsUpdated (1.89s)
=== RUN   TestAccTeamcityBuildTriggerSchedule_DefaultOptions
--- PASS: TestAccTeamcityBuildTriggerSchedule_DefaultOptions (1.49s)
=== RUN   TestAccTeamcityBuildTriggerVcs_Basic
--- PASS: TestAccTeamcityBuildTriggerVcs_Basic (1.36s)
=== RUN   TestAccTeamcityBuildTriggerVcs_Update
--- PASS: TestAccTeamcityBuildTriggerVcs_Update (2.28s)
=== RUN   TestAccTeamcityFeatureCommitStatusPublisher_Github
--- PASS: TestAccTeamcityFeatureCommitStatusPublisher_Github (1.77s)
=== RUN   TestAccTeamcityFeatureCommitStatusPublisher_GithubUpdate
--- PASS: TestAccTeamcityFeatureCommitStatusPublisher_GithubUpdate (2.26s)
=== RUN   TestAccGroupCreate_Basic
--- PASS: TestAccGroupCreate_Basic (0.16s)
=== RUN   TestAccGroupCreate_BasicUpdate
--- PASS: TestAccGroupCreate_BasicUpdate (0.31s)
=== RUN   TestAccTeamcityProject_Basic
--- PASS: TestAccTeamcityProject_Basic (0.43s)
=== RUN   TestAccTeamcityProject_Full
--- PASS: TestAccTeamcityProject_Full (0.54s)
=== RUN   TestAccTeamcityProject_Parent
--- PASS: TestAccTeamcityProject_Parent (0.78s)
=== RUN   TestAccTeamcityProject_Update
--- PASS: TestAccTeamcityProject_Update (0.69s)
=== RUN   TestAccTeamcitySnapshotDependency_Basic
--- PASS: TestAccTeamcitySnapshotDependency_Basic (0.89s)
=== RUN   TestAccTeamcitySnapshotDependency_Updated
--- PASS: TestAccTeamcitySnapshotDependency_Updated (1.46s)
=== RUN   TestAccVcsRootGit_Basic
--- PASS: TestAccVcsRootGit_Basic (0.42s)
=== RUN   TestAccVcsRootGit_UpdateBasic
--- PASS: TestAccVcsRootGit_UpdateBasic (1.06s)
=== RUN   TestAccVcsRootGit_UserpassAuth
--- PASS: TestAccVcsRootGit_UserpassAuth (0.43s)
=== RUN   TestAccVcsRootGit_SshUploadedKeyAuth
--- PASS: TestAccVcsRootGit_SshUploadedKeyAuth (0.36s)
=== RUN   TestAccVcsRootGit_AgentSettings
--- PASS: TestAccVcsRootGit_AgentSettings (0.46s)
=== RUN   TestAccVcsRootGit_Delete
--- PASS: TestAccVcsRootGit_Delete (0.22s)
PASS
ok  	github.com/cvbarros/terraform-provider-teamcity/teamcity	64.527s
```

Also adds support for HTTP Proxies by overriding the HTTP Client - since we need to pass this in anyway