### PR TITLE
New Data Source/Resource: `teamcity_agent_pool`

### DIFF
--- a/teamcity/data_source_agent_pool.go
+++ b/teamcity/data_source_agent_pool.go
@@ -1,0 +1,42 @@
+package teamcity
+
+import (
+	api "github.com/cvbarros/go-teamcity/teamcity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAgentPool() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAgentPoolRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"max_agents": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAgentPoolRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	name := d.Get("name").(string)
+	agentPool, err := client.AgentPools.GetByName(name)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(agentPool.ID)
+	d.Set("name", agentPool.Name)
+	maxAgents := -1
+	if agentPool.MaxAgents != nil {
+		maxAgents = *agentPool.MaxAgents
+	}
+	d.Set("max_agents", maxAgents)
+
+	return nil
+}

--- a/teamcity/data_source_agent_pool_test.go
+++ b/teamcity/data_source_agent_pool_test.go
@@ -1,0 +1,31 @@
+package teamcity_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDataSourceAgentPool_Basic(t *testing.T) {
+	resName := "data.teamcity_agent_pool.project"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAgentPool,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resName, "name", "Default"),
+					resource.TestCheckResourceAttr(resName, "max_agents", "-1"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceAgentPool = `
+data "teamcity_agent_pool" "test" {
+  name = "Default"
+}
+`

--- a/teamcity/provider.go
+++ b/teamcity/provider.go
@@ -22,7 +22,8 @@ func Provider() terraform.ResourceProvider {
 			"teamcity_group":                           resourceGroup(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
-			"teamcity_project": dataSourceProject(),
+			"teamcity_agent_pool": dataSourceAgentPool(),
+			"teamcity_project":    dataSourceProject(),
 		},
 		Schema: map[string]*schema.Schema{
 			"address": &schema.Schema{

--- a/teamcity/provider.go
+++ b/teamcity/provider.go
@@ -20,6 +20,7 @@ func Provider() terraform.ResourceProvider {
 			"teamcity_agent_requirement":               resourceAgentRequirement(),
 			"teamcity_feature_commit_status_publisher": resourceFeatureCommitStatusPublisher(),
 			"teamcity_group":                           resourceGroup(),
+			"teamcity_agent_pool":                      resourceAgentPool(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"teamcity_agent_pool": dataSourceAgentPool(),

--- a/teamcity/resource_agent_pool.go
+++ b/teamcity/resource_agent_pool.go
@@ -1,0 +1,98 @@
+package teamcity
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	api "github.com/cvbarros/go-teamcity/teamcity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAgentPool() *schema.Resource {
+	return &schema.Resource{
+		// the TC Docs say this supports update - but the documented API doesn't work
+		// (returns 405 Method Not Allowed) so for the moment this can't support update
+		Create: resourceAgentPoolCreate,
+		Read:   resourceAgentPoolRead,
+		Delete: resourceAgentPoolDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"max_agents": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+				Default:  -1,
+			},
+		},
+	}
+}
+
+func resourceAgentPoolCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	agentPool := api.AgentPool{
+		Name: d.Get("name").(string),
+	}
+	if v := d.Get("max_agents").(int); v >= 0 {
+		agentPool.MaxAgents = &v
+	}
+
+	createdAgentPool, err := client.AgentPools.Create(agentPool)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(fmt.Sprintf("%s", createdAgentPool.ID))
+
+	return resourceAgentPoolRead(d, client)
+}
+
+func resourceAgentPoolRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	id, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return err
+	}
+
+	agentPool, err := client.AgentPools.GetByID(id)
+	if err != nil {
+		if strings.Contains(err.Error(), "404") {
+			log.Printf("[DEBUG] Agent Pool not found - removing from state!")
+			d.SetId("")
+			return nil
+		}
+
+		return err
+	}
+
+	d.Set("name", agentPool.Name)
+	maxAgents := -1
+	if agentPool.MaxAgents != nil {
+		maxAgents = *agentPool.MaxAgents
+	}
+	d.Set("max_agents", maxAgents)
+
+	return nil
+}
+
+func resourceAgentPoolDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	id, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return err
+	}
+
+	return client.AgentPools.Delete(id)
+}

--- a/teamcity/resource_agent_pool_test.go
+++ b/teamcity/resource_agent_pool_test.go
@@ -1,0 +1,129 @@
+package teamcity_test
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	api "github.com/cvbarros/go-teamcity/teamcity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccTeamCityAgentPool_Basic(t *testing.T) {
+	resName := "teamcity_agent_pool.test"
+	name := fmt.Sprintf("Pool %d", time.Now().Unix())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTeamCityAgentPoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTeamCityAgentPoolBasicConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTeamCityAgentPoolExists(resName),
+					resource.TestCheckResourceAttr(resName, "max_agents", "-1"),
+					resource.TestCheckResourceAttr(resName, "name", name),
+				),
+			},
+			{
+				ResourceName:      resName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccTeamCityAgentPool_Complete(t *testing.T) {
+	resName := "teamcity_agent_pool.test"
+	name := fmt.Sprintf("Pool %d", time.Now().Unix())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTeamCityAgentPoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTeamCityAgentPoolCompleteConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTeamCityAgentPoolExists(resName),
+					resource.TestCheckResourceAttr(resName, "max_agents", "5"),
+					resource.TestCheckResourceAttr(resName, "name", name),
+				),
+			},
+			{
+				ResourceName:      resName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckTeamCityAgentPoolExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*api.Client)
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		id, err := strconv.Atoi(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		_, err = client.AgentPools.GetByID(id)
+		if err != nil {
+			return fmt.Errorf("Received an error retrieving agent pool: %s", err)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckTeamCityAgentPoolDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*api.Client)
+	for _, r := range s.RootModule().Resources {
+		if r.Type != "teamcity_agent_pool" {
+			continue
+		}
+
+		id, err := strconv.Atoi(r.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		_, err = client.AgentPools.GetByID(id)
+		if err != nil {
+			if strings.Contains(err.Error(), "404") {
+				continue
+			}
+			return fmt.Errorf("Received an error retrieving the agent pool: %s", err)
+		}
+
+		return fmt.Errorf("Agent Pool still exists")
+	}
+	return nil
+}
+
+func testAccTeamCityAgentPoolBasicConfig(name string) string {
+	return fmt.Sprintf(`
+resource "teamcity_agent_pool" "test" {
+  name = %s
+}
+`, name)
+}
+
+func testAccTeamCityAgentPoolCompleteConfig(name string) string {
+	return fmt.Sprintf(`
+resource "teamcity_agent_pool" "test" {
+  name       = %s
+  max_agents = 5
+}
+`, name)
+}

--- a/website/docs/d/agent_pool.html.markdown
+++ b/website/docs/d/agent_pool.html.markdown
@@ -1,0 +1,31 @@
+---
+subcategory: "Agent Pools"
+layout: "teamcity"
+page_title: "TeamCity: Data Source - teamcity_agent_pool"
+description: |-
+  Retrieves information about an existing TeamCity Agent Pool
+---
+
+# Data Source: teamcity_agent_pool
+
+Retrieves information about an existing TeamCity Agent Pool
+
+## Example Usage
+
+```hcl
+data "teamcity_project" "by-name" {
+  name = "Default"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The Name of the Agent Pool.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `max_agents` - The maximum number of agents in this pool. If set to `unlimited` this'll be `-1`.

--- a/website/docs/r/agent_pool.html.markdown
+++ b/website/docs/r/agent_pool.html.markdown
@@ -1,0 +1,41 @@
+---
+subcategory: "Agent Pools"
+layout: teamcity
+page_title: "TeamCity: Resource - teamcity_agent_pool"
+description: |-
+  Manages an Agent Pool
+---
+
+# teamcity_agent_pool
+
+Manages an Agent Pool
+
+## Example Usage
+
+```hcl
+resource "teamcity_agent_pool" "example" {
+  name = "Example"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies the name which should be used for this Agent Pool.
+
+* `max_agents` - (Optional) Specifies the maximum number of Build Agents which can be associated with this Agent Pool. Defaults to `-1` which means `unlimited`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The auto-generated ID of the Agent Pool.
+
+## Import
+
+Agent Pools can be imported using their ID, e.g.
+
+```
+$ terraform import teamcity_agent_pool.example 28
+```

--- a/website/teamcity.erb
+++ b/website/teamcity.erb
@@ -11,6 +11,9 @@
               <a href="#">Data Sources</a>
               <ul class="nav">
                 <li>
+                    <a href="/docs/providers/teamcity/d/agent_pool.html">teamcity_agent_pool</a>
+                </li>
+                <li>
                     <a href="/docs/providers/teamcity/d/project.html">teamcity_project</a>
                 </li>
               </ul>


### PR DESCRIPTION
This PR includes a new Data Source & Resource for Agent Pools - which can be managed via:

```
data "teamcity_agent_pool" "test" {
  name = "Default"
}

resource "teamcity_agent_pool" "test" {
  name = "Example"
}
```

Dependent on https://github.com/cvbarros/go-teamcity/pull/79 - but should compile & the tests pass once that's available 😄