### PR TITLE
build-config/project: updating the `name` field / making `step` Optional & Computed

### DIFF
--- a/teamcity/resource_build_config.go
+++ b/teamcity/resource_build_config.go
@@ -102,6 +102,7 @@ func resourceBuildConfig() *schema.Resource {
 			"step": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"step_id": {

--- a/teamcity/resource_build_config.go
+++ b/teamcity/resource_build_config.go
@@ -67,7 +67,6 @@ func resourceBuildConfig() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 			"is_template": {
 				Type:     schema.TypeBool,
@@ -306,6 +305,10 @@ func resourceBuildConfigUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if err != nil {
 		return err
+	}
+
+	if d.HasChange("name") {
+		dt.Name = d.Get("name").(string)
 	}
 
 	var changed bool

--- a/teamcity/resource_build_config_test.go
+++ b/teamcity/resource_build_config_test.go
@@ -3,11 +3,12 @@ package teamcity_test
 import (
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
 	api "github.com/cvbarros/go-teamcity/teamcity"
 )
@@ -195,6 +196,7 @@ func TestAccBuildConfig_UpdateBasic(t *testing.T) {
 				Config: TestAccBuildConfigBasicUpdated,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBuildConfigExists(resName, &bc),
+					resource.TestCheckResourceAttr(resName, "name", "build config updated"),
 					resource.TestCheckResourceAttr(resName, "description", "build config test desc updated"),
 				),
 			},
@@ -861,7 +863,7 @@ resource "teamcity_project" "build_config_project_test" {
 }
 
 resource "teamcity_build_config" "build_configuration_test" {
-	name = "build config test"
+	name = "build config updated"
 	project_id = "${teamcity_project.build_config_project_test.id}"
 	description = "build config test desc updated"
 	settings {

--- a/teamcity/resource_project.go
+++ b/teamcity/resource_project.go
@@ -21,7 +21,6 @@ func resourceProject() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 			"description": {
 				Type:     schema.TypeString,
@@ -83,6 +82,10 @@ func resourceProjectUpdate(d *schema.ResourceData, meta interface{}) error {
 	dt, err := client.Projects.GetByID(d.Id())
 	if err != nil {
 		return err
+	}
+
+	if d.HasChange("name") {
+		dt.Name = d.Get("name").(string)
 	}
 
 	if v, ok := d.GetOk("description"); ok {

--- a/teamcity/resource_project_test.go
+++ b/teamcity/resource_project_test.go
@@ -94,7 +94,7 @@ func TestAccTeamcityProject_Update(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckTeamcityProjectDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccTeamcityProjectFull,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTeamcityProjectExists(resName, &p),
@@ -113,10 +113,11 @@ func TestAccTeamcityProject_Update(t *testing.T) {
 					testAccCheckProjectParameter(&p, api.ParameterTypes.System, "param6", "sys_value2"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccTeamcityProjectFullUpdated,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTeamcityProjectExists(resName, &p),
+					resource.TestCheckResourceAttr(resName, "description", "updated project"),
 					resource.TestCheckResourceAttr(resName, "description", "Test Project Updated"),
 					resource.TestCheckResourceAttr(resName, "config_params.param1", "config_value1"),
 					resource.TestCheckResourceAttr(resName, "config_params.param2", "config_value2"),
@@ -240,7 +241,7 @@ resource "teamcity_project" "testproj" {
 
 const testAccTeamcityProjectFullUpdated = `
 resource "teamcity_project" "testproj" {
-	name = "test_project"
+	name = "updated project"
 	description = "Test Project Updated"
 
 	config_params = {


### PR DESCRIPTION
This PR makes three changes:

* Build Configuration: support for updating the Name
* Build Configuration: making the `step` block Computed
* Project: support for updating the Name

When creating a Build Configuration based on a Template, once the build has first been created - Terraform shows a diff because the Build Steps are missing from the configuration but returned from the API.

As such this commit makes this block `Optional` & `Computed` so that this diff can be omitted if a user hasn't specified any `step` blocks to override this in the config (e.g. wants to /only/ use steps from the template).