### PR TITLE
r/project: making the parent id field un-computed

### DIFF
--- a/teamcity/data_source_project.go
+++ b/teamcity/data_source_project.go
@@ -67,7 +67,11 @@ func dataSourceProjectRead(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(dt.ID)
 	d.Set("name", dt.Name)
 	d.Set("project_id", dt.ID)
-	d.Set("parent_project_id", dt.ParentProjectID)
+	parentProjectId := dt.ParentProjectID
+	if parentProjectId == "_Root" {
+		parentProjectId = ""
+	}
+	d.Set("parent_project_id", parentProjectId)
 	d.Set("url", dt.WebURL)
 	return nil
 }

--- a/teamcity/data_source_project_test.go
+++ b/teamcity/data_source_project_test.go
@@ -39,7 +39,7 @@ func TestAccDataSourceProject_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resName, "name", "Test Project"),
 					resource.TestCheckResourceAttr(resName, "project_id", "TestProject"),
-					resource.TestCheckResourceAttr(resName, "parent_project_id", "_Root"),
+					resource.TestCheckResourceAttr(resName, "parent_project_id", ""),
 					resource.TestCheckResourceAttr(resName, "url", "http://127.0.0.1:8112/project.html?projectId=TestProject"),
 				),
 			},

--- a/teamcity/resource_project.go
+++ b/teamcity/resource_project.go
@@ -85,14 +85,16 @@ func resourceProjectUpdate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	if v, ok := d.GetOk("description"); ok {
-		dt.Description = v.(string)
+	if d.HasChange("description") {
+		dt.Description = d.Get("description").(string)
 	}
 
-	if v, ok := d.GetOk("parent_id"); ok {
-		if v != "" {
-			dt.SetParentProject(v.(string))
+	if d.HasChange("parent_id") {
+		parentId := d.Get("parent_id").(string)
+		if parentId == "" {
+			parentId = "_Root"
 		}
+		dt.SetParentProject(parentId)
 	}
 
 	dt.Parameters, err = expandParameterCollection(d)

--- a/teamcity/resource_project.go
+++ b/teamcity/resource_project.go
@@ -2,9 +2,10 @@ package teamcity
 
 import (
 	"fmt"
+	"log"
+
 	api "github.com/cvbarros/go-teamcity/teamcity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"log"
 )
 
 func resourceProject() *schema.Resource {
@@ -30,7 +31,6 @@ func resourceProject() *schema.Resource {
 			"parent_id": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
 			},
 			"env_params": {
 				Type:     schema.TypeMap,
@@ -124,8 +124,15 @@ func resourceProjectRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	flattenParameterCollection(d, dt.Parameters)
-	return nil
+	d.Set("name", dt.Name)
+	d.Set("description", dt.Description)
+	parentProjectId := dt.ParentProjectID
+	if parentProjectId == "_Root" {
+		parentProjectId = ""
+	}
+	d.Set("parent_id", parentProjectId)
+
+	return flattenParameterCollection(d, dt.Parameters)
 }
 
 func resourceProjectDelete(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
This is set to Computed since when creating a project in the root, there's a parent ID of `_Root` - however to make this diff work properly, we should be able to set this field to a value if it's not "root" to signify if there's a Parent Project ID or not

Ultimately this enables moving projects from a nested project -> the root