### PR TITLE
Fixed some website/docs/r terraform templates

### DIFF
--- a/website/docs/r/artifact_dependency.html.markdown
+++ b/website/docs/r/artifact_dependency.html.markdown
@@ -30,6 +30,7 @@ resource "teamcity_build_config" "dependant" {
 resource "teamcity_artifact_dependency" "dependency" {
   source_build_config_id = teamcity_build_config.source.id
   build_config_id        = teamcity_build_config.dependant.id
+  path_rules             = ["+:**/* => target_dir", "-:**/folder1 => target_dir"]
 }
 ```
 
@@ -45,7 +46,7 @@ The following arguments are supported:
 
 * `revision` - (Optional) If using `buildNumber`, this is the parameter for which specific build number to consider. In case of `buildTag`, this refers to the tag name. Required in these cases.
 
-* `path_rules` - (Optional) A list of rules to match files that will have to be dowloaded from the source build that output artifacts. They can be specified in the format [+:|-:]SourcePath[!ArchivePath][=>DestinationPath].
+* `path_rules` - (Required) A list of rules to match files that will have to be dowloaded from the source build that output artifacts. They can be specified in the format [+:|-:]SourcePath[!ArchivePath][=>DestinationPath].
 
 * `clean_destination` - (Optional) If true, this will clean destination paths before downloading artifacts.
 

--- a/website/docs/r/build_trigger_build_finish.html.markdown
+++ b/website/docs/r/build_trigger_build_finish.html.markdown
@@ -29,7 +29,7 @@ resource "teamcity_build_config" "build_release" {
   name       = "Build Release"
 
   step {
-    type = "command_line"
+    type = "cmd_line"
     file = "build.sh"
     args = "-t buildrelease"
   }
@@ -53,9 +53,10 @@ resource "teamcity_build_config" "triggered_build" {
 }
 
 resource "teamcity_build_trigger_build_finish" "buildrelease_finish_trigger" {
-  build_config_id       = teamcity_build_config.build_release.id
-  after_successful_only = true
-  branch_filter         = ["master", "feature"]
+  build_config_id        = teamcity_build_config.build_release.id
+  source_build_config_id = teamcity_build_config.triggered_build.id
+  after_successful_only  = true
+  branch_filter          = ["master", "feature"]
 }
 ```
 

--- a/website/docs/r/vcs_root_git.html.markdown
+++ b/website/docs/r/vcs_root_git.html.markdown
@@ -31,7 +31,7 @@ resource "teamcity_vcs_root_git" "vcsroot" {
   ]
   enable_branch_spec_tags = false
   username_style          = "userid"
-  submodule_checkout      = true
+  submodule_checkout      = "ignore"
 
   # Auth block configures the authentication to Git VCS
   auth {


### PR DESCRIPTION
Thanks for creating this provider. I found some fixes for the website/docs

- Fixed vcs-root-git.submodule_checkout to allowed value 'ignore'
- Added missing teamcity_build_trigger_build_finish.source_build_config_id in example.
- Fixed teamcity_build_config.step.type to allowed value 'cmd_line'
- Fixed missing required teamcity_artifact_dependency.path_rules
   - https://github.com/cvbarros/terraform-provider-teamcity/blob/6bae17d8de1768c038393bd1e8dce46a674e803f/teamcity/resource_artifact_dependency.go#L45-L50