### PR TITLE
added a a check for null build steps

### DIFF
--- a/teamcity/resource_build_config.go
+++ b/teamcity/resource_build_config.go
@@ -704,18 +704,20 @@ func flattenBuildConfigOptionsRaw(dt *api.BuildTypeOptions) map[string]interface
 }
 
 func flattenBuildStep(s api.Step) (map[string]interface{}, error) {
-	mapType := stepTypeMap[s.Type()]
 	var out map[string]interface{}
 	var err error
-	switch mapType {
-	case "powershell":
-		out, err = flattenBuildStepPowershell(s.(*api.StepPowershell)), nil
-	case "cmd_line":
-		out, err = flattenBuildStepCmdLine(s.(*api.StepCommandLine)), nil
-	default:
-		return nil, fmt.Errorf("build step type '%s' not supported", s.Type())
+	if s != nil {
+		mapType := stepTypeMap[s.Type()]
+		switch mapType {
+		case "powershell":
+			out, err = flattenBuildStepPowershell(s.(*api.StepPowershell)), nil
+		case "cmd_line":
+			out, err = flattenBuildStepCmdLine(s.(*api.StepCommandLine)), nil
+		default:
+			return nil, fmt.Errorf("build step type '%s' not supported", s.Type())
+		}
+		out["step_id"] = s.GetID()
 	}
-	out["step_id"] = s.GetID()
 	return out, err
 }
 


### PR DESCRIPTION
this addresses the issue in https://github.com/cvbarros/terraform-provider-teamcity/issues/108. When an attached template adds build steps, it can contain a null build step in the list that is returned, causing the issues described.